### PR TITLE
fix: rate limiter memory leak and image cache bounds

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -10,6 +10,8 @@ const nextConfig: NextConfig = {
         pathname: "/**",
       },
     ],
+    minimumCacheTTL: 3600, // evict optimized images after 1 hour
+    deviceSizes: [640, 1080, 1920], // 3 variants instead of the default 7
   },
 };
 

--- a/src/lib/rate-limiter.ts
+++ b/src/lib/rate-limiter.ts
@@ -5,6 +5,10 @@ import type {
   RateLimitStore,
 } from "../types/rate-limit";
 
+// Must match RATE_LIMITS.*.windowMs — entries are only useful within the rate
+// limit window, so we clean them up as soon as they age out of it.
+const ENTRY_MAX_AGE_MS = parseInt(process.env.RATE_LIMIT_WINDOW_MS || "3600000"); // 1 hour
+
 class RateLimiter {
   private store: RateLimitStore;
   private readonly cleanupInterval = 5 * 60 * 1000; // 5 minutes
@@ -80,26 +84,27 @@ class RateLimiter {
    */
   private cleanup(): void {
     const now = Date.now();
-    const maxAge = 24 * 60 * 60 * 1000; // 24 hours
+    const windowStart = now - ENTRY_MAX_AGE_MS;
 
     // Clean IP entries
     for (const [key, entry] of this.store.byIP) {
-      if (now - entry.firstRequest > maxAge && entry.requests.length === 0) {
+      entry.requests = entry.requests.filter((ts) => ts > windowStart);
+      if (entry.requests.length === 0) {
         this.store.byIP.delete(key);
       }
     }
 
     // Clean email entries
     for (const [key, entry] of this.store.byEmail) {
-      if (now - entry.firstRequest > maxAge && entry.requests.length === 0) {
+      entry.requests = entry.requests.filter((ts) => ts > windowStart);
+      if (entry.requests.length === 0) {
         this.store.byEmail.delete(key);
       }
     }
 
     // Clean global entries
-    const windowStart = now - maxAge;
     this.store.global.requests = this.store.global.requests.filter(
-      (timestamp) => timestamp > windowStart
+      (ts) => ts > windowStart
     );
 
     this.store.lastCleanup = now;


### PR DESCRIPTION
## Problem
The service was restarting on Render due to exceeding its memory limit. Two causes identified:

1. **Rate limiter memory leak** — the cleanup function checked `entry.requests.length === 0` without first filtering out stale timestamps. Since filtering only happened in `checkRateLimit`, entries for IPs that never returned were never cleaned up. Every unique visitor left a permanent footprint in memory.

2. **Unbounded image optimization cache** — no TTL or variant count limit was set, so Next.js accumulated optimized image variants in memory indefinitely.

## Changes
- `src/lib/rate-limiter.ts` — Introduced `ENTRY_MAX_AGE_MS` const (defaults to `RATE_LIMIT_WINDOW_MS`, 1 hour) shared by both the rate limit window and cleanup logic. Fixed `cleanup()` to filter stale timestamps before checking if an entry is empty.
- `next.config.ts` — Added `minimumCacheTTL: 3600` and reduced `deviceSizes` from 7 variants to 3.

## Acceptance Criteria

**Rate limiter**

Scenario: IP entries are removed after the rate limit window expires
  Given a visitor has submitted the contact form
  When more than 1 hour has passed and the cleanup runs
  Then that IP's entry is removed from memory

Scenario: Cleanup age stays in sync with rate limit window
  Given RATE_LIMIT_WINDOW_MS is set to a custom value
  When the cleanup runs
  Then entries older than that same window are evicted — not a hardcoded 24h

Scenario: Active entries within the window are not removed
  Given a visitor submitted the contact form 30 minutes ago
  When the cleanup runs
  Then their entry is retained and the rate limit still applies

**Image cache**

Scenario: Optimized image variants are bounded
  Given the site has been running for over 1 hour
  When Next.js serves an image
  Then cached variants older than 1 hour are eligible for eviction

Scenario: Fewer size variants are generated
  Given a page with images loads
  When Next.js generates optimized variants
  Then it produces 3 size variants (640, 1080, 1920px) instead of 7